### PR TITLE
Add load more functionality and archive thumbnails

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -16,5 +16,6 @@ export const siteConfig = {
     categoryId: 'DIC_kwDODdlXnc4Cx09S',
   },
   googleAnalytics: 'G-2HB2W9WDMR',
-  postsPerPage: 7,
+  postsPerPage: 12,
+  postsPerLoadMore: 12,
 };

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -76,6 +76,13 @@ const postsByYearAndMonth = Object.entries(postsByYear)
                                   day: '2-digit' 
                                 })}
                               </span>
+                              <div class="archive-thumbnail">
+                                <img 
+                                  src={`/img/${post.data.image || 'article-header.jpg'}`} 
+                                  alt={post.data.title}
+                                  loading="lazy"
+                                />
+                              </div>
                               <a class="archive-link" href={`/${post.slug}/`}>
                                 {post.data.title}
                               </a>
@@ -169,7 +176,7 @@ const postsByYearAndMonth = Object.entries(postsByYear)
   .archive-item {
     margin-bottom: 0.75rem;
     display: flex;
-    align-items: baseline;
+    align-items: center;
     gap: 1rem;
     flex-wrap: wrap;
   }
@@ -180,6 +187,27 @@ const postsByYearAndMonth = Object.entries(postsByYear)
     min-width: 60px;
     font-size: 0.9rem;
     font-weight: 500;
+  }
+
+  .archive-thumbnail {
+    width: 60px;
+    height: 60px;
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    flex-shrink: 0;
+    box-shadow: var(--shadow-sm);
+    transition: transform var(--transition-fast);
+  }
+
+  .archive-thumbnail:hover {
+    transform: scale(1.05);
+  }
+
+  .archive-thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
   }
 
   .archive-link {
@@ -247,17 +275,30 @@ const postsByYearAndMonth = Object.entries(postsByYear)
     }
 
     .archive-item {
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 0.25rem;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
     }
 
     .archive-date {
       min-width: auto;
+      font-size: 0.8rem;
+    }
+
+    .archive-thumbnail {
+      width: 50px;
+      height: 50px;
+    }
+
+    .archive-link {
+      flex: 1;
+      min-width: 0;
     }
 
     .archive-tags {
       margin-top: 0.25rem;
+      width: 100%;
+      margin-left: 110px;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,8 +132,10 @@ const allPostsData = sortedPosts.map(post => ({
                   </a>
                 </div>
                 <div id="loading-indicator" class="loading-indicator" style="display: none;">
-                  <ion-icon name="hourglass-outline"></ion-icon>
-                  Loading more articles...
+                  <div class="loading-bar">
+                    <div class="loading-bar-fill"></div>
+                  </div>
+                  <span class="loading-text">Loading more articles...</span>
                 </div>
               </div>
             </div>
@@ -368,21 +370,45 @@ const allPostsData = sortedPosts.map(post => ({
   .loading-indicator {
     margin-top: var(--space-lg);
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
     gap: var(--space-sm);
     color: var(--text-secondary);
-    font-size: 1rem;
   }
 
-  .loading-indicator ion-icon {
-    font-size: 1.5rem;
-    animation: spin 1s linear infinite;
+  .loading-bar {
+    width: 200px;
+    height: 4px;
+    background: var(--border-color);
+    border-radius: 2px;
+    overflow: hidden;
+    position: relative;
   }
 
-  @keyframes spin {
-    from { transform: rotate(0deg); }
-    to { transform: rotate(360deg); }
+  .loading-bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--accent-color), var(--link-hover));
+    border-radius: 2px;
+    animation: fillBar 1s ease-in-out infinite;
+  }
+
+  @keyframes fillBar {
+    0% {
+      width: 0%;
+      margin-left: 0%;
+    }
+    50% {
+      width: 50%;
+      margin-left: 25%;
+    }
+    100% {
+      width: 0%;
+      margin-left: 100%;
+    }
+  }
+
+  .loading-text {
+    font-size: 0.875rem;
   }
 
   .view-more {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,16 @@ import { siteConfig } from '../config';
 const posts = await getPublishedPosts();
 const sortedPosts = posts.sort((a, b) => b.data.date.valueOf() - a.data.date.valueOf());
 const recentPosts = sortedPosts.slice(0, siteConfig.postsPerPage);
+
+// Prepare all posts data for client-side pagination
+const allPostsData = sortedPosts.map(post => ({
+  slug: post.slug,
+  title: post.data.title,
+  description: post.data.description,
+  date: post.data.date.toISOString(),
+  image: post.data.image || 'article-header.jpg',
+  tags: post.data.tags || []
+}));
 ---
 
 <BaseLayout 
@@ -101,14 +111,18 @@ const recentPosts = sortedPosts.slice(0, siteConfig.postsPerPage);
           </div>
           
           {sortedPosts.length > siteConfig.postsPerPage && (
-            <div class="explore-more">
+            <div class="explore-more" id="explore-section">
               <div class="explore-content">
                 <h3 class="explore-title">Ready to Dive Deeper?</h3>
                 <p class="explore-description">
                   Explore the complete archive of cloud architecture insights, leadership lessons, and mental health in tech.
                 </p>
                 <div class="explore-actions">
-                  <a href="/archive/" class="button button-primary">
+                  <button id="load-more-btn" class="button button-primary" data-offset={siteConfig.postsPerPage}>
+                    <ion-icon name="arrow-down-circle-outline"></ion-icon>
+                    Load More Articles
+                  </button>
+                  <a href="/archive/" class="button button-secondary">
                     <ion-icon name="library-outline"></ion-icon>
                     Browse All Articles
                   </a>
@@ -116,6 +130,10 @@ const recentPosts = sortedPosts.slice(0, siteConfig.postsPerPage);
                     <ion-icon name="pricetags-outline"></ion-icon>
                     Explore by Topic
                   </a>
+                </div>
+                <div id="loading-indicator" class="loading-indicator" style="display: none;">
+                  <ion-icon name="hourglass-outline"></ion-icon>
+                  Loading more articles...
                 </div>
               </div>
             </div>
@@ -347,6 +365,26 @@ const recentPosts = sortedPosts.slice(0, siteConfig.postsPerPage);
     font-size: 1.25rem;
   }
 
+  .loading-indicator {
+    margin-top: var(--space-lg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-sm);
+    color: var(--text-secondary);
+    font-size: 1rem;
+  }
+
+  .loading-indicator ion-icon {
+    font-size: 1.5rem;
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
   .view-more {
     text-align: center;
     margin-top: var(--space-xl);
@@ -364,5 +402,100 @@ const recentPosts = sortedPosts.slice(0, siteConfig.postsPerPage);
     .featured-content {
       padding: var(--space-lg);
     }
+
+    .explore-actions {
+      flex-direction: column;
+    }
+
+    .explore-actions .button {
+      width: 100%;
+    }
   }
 </style>
+
+<script define:vars={{ allPostsData, postsPerPage: siteConfig.postsPerPage }}>
+  document.addEventListener('DOMContentLoaded', () => {
+    const loadMoreBtn = document.getElementById('load-more-btn');
+    const articlesGrid = document.querySelector('.articles-grid');
+    const loadingIndicator = document.getElementById('loading-indicator');
+    const exploreSection = document.getElementById('explore-section');
+
+    if (!loadMoreBtn || !articlesGrid) return;
+
+    let currentOffset = postsPerPage;
+
+    loadMoreBtn.addEventListener('click', () => {
+      console.log('Loading more posts with offset:', currentOffset);
+      
+      // Show loading state
+      loadMoreBtn.disabled = true;
+      if (loadingIndicator) loadingIndicator.style.display = 'flex';
+
+      // Simulate async for smooth UX
+      setTimeout(() => {
+        const postsToLoad = allPostsData.slice(currentOffset, currentOffset + 12);
+        console.log('Loaded posts:', postsToLoad.length);
+
+        // Add new articles to grid
+        postsToLoad.forEach((post) => {
+          const article = document.createElement('article');
+          article.className = 'article';
+          
+          const dateObj = new Date(post.date);
+          const formattedDate = dateObj.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+          });
+
+          article.innerHTML = `
+            <div class="article-image" style="background-image: url(/img/${post.image})">
+              <a href="/${post.slug}/" class="image-link"></a>
+            </div>
+            <div class="article-content">
+              <div class="article-header">
+                <div class="article-date">
+                  <time datetime="${post.date}">${formattedDate}</time>
+                </div>
+                ${post.tags.length > 0 ? `
+                  <div class="article-tags">
+                    ${post.tags.map((tag) => `<a href="/tags/${tag}/" class="tag">${tag}</a>`).join('')}
+                  </div>
+                ` : ''}
+              </div>
+              <h3 class="article-title">
+                <a href="/${post.slug}/">${post.title}</a>
+              </h3>
+              <p class="article-excerpt">
+                ${post.description || 'Read more about this article...'}
+              </p>
+            </div>
+          `;
+
+          articlesGrid.appendChild(article);
+        });
+
+        // Update offset for next load
+        currentOffset += postsToLoad.length;
+        console.log('New offset:', currentOffset);
+
+        // Hide button if no more posts
+        const hasMore = currentOffset < allPostsData.length;
+        if (!hasMore) {
+          loadMoreBtn.style.display = 'none';
+          
+          // Update section message
+          if (exploreSection) {
+            const title = exploreSection.querySelector('.explore-title');
+            const description = exploreSection.querySelector('.explore-description');
+            if (title) title.textContent = "You've Seen It All!";
+            if (description) description.textContent = "Browse the archive or explore by topic to find exactly what you're looking for.";
+          }
+        }
+
+        loadMoreBtn.disabled = false;
+        if (loadingIndicator) loadingIndicator.style.display = 'none';
+      }, 300);
+    });
+  });
+</script>


### PR DESCRIPTION
- Increase homepage from 7 to 12 initial posts (1 featured + 11 grid)
- Add 'Load More Articles' button to homepage with client-side pagination
- Embed all post data in page for static site compatibility
- Add 60x60px thumbnails to archive page between date and title
- Update 'Ready to Dive Deeper' section with 3 action buttons
- Remove unused API endpoint (not needed for static builds)